### PR TITLE
Test commit: Check for protoc version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -791,6 +791,8 @@ jobs:
        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
        with:
         version: ${{ env.PROTOC_VERSION }}
+     - name: Check for Protoc
+       run: echo $(which protoc)
      - name: Cache builds
        # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
        uses: actions/cache@30f413bfed0a2bc738fdfd409e5a9e96b24545fd #v2.1.7


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Testing.

#### What is the current behavior?
GH actions for recent Pulls (see: https://github.com/ossf/scorecard/runs/7198422780) are failing because `protoc` is not in the path. Debug it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
