### PR TITLE
🌱 Build/test fixes: Install protoc and protoc-gen-go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,10 +169,6 @@ jobs:
        with:
          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
-     - name: Sleep
-       run: sleep 10m  # This is workaround to avoid the action failures for installing the protoc
-       shell: bash
-
      - name: Install Protoc
        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
        with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -835,6 +835,10 @@ jobs:
        with:
          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
+     - name: Install Protoc
+       uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+       with:
+        version: ${{ env.PROTOC_VERSION }}
      - name: Cache builds
        # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
        uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d #v2.1.7

--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,9 @@ build: $(build-targets)
 
 build-proto: ## Compiles and generates all required protobufs
 build-proto: cron/internal/data/request.pb.go cron/internal/data/metadata.pb.go
-cron/internal/data/request.pb.go: cron/internal/data/request.proto |  $(PROTOC)
+cron/internal/data/request.pb.go: cron/internal/data/request.proto |  $(PROTOC) install
 	protoc --go_out=../../../ cron/internal/data/request.proto
-cron/internal/data/metadata.pb.go: cron/internal/data/metadata.proto |  $(PROTOC)
+cron/internal/data/metadata.pb.go: cron/internal/data/metadata.proto |  $(PROTOC) install
 	protoc --go_out=../../../ cron/internal/data/metadata.proto
 
 generate-mocks: ## Compiles and generates all mocks using mockgen.


### PR DESCRIPTION
##### What kind of change does this PR introduce?
Build and test changes only. This PR updates the `make` target for building cron protobufs to require `protoc-gen-go` to be installed first.

##### What is the current behavior?
GH actions for recent Pulls (see: https://github.com/ossf/scorecard/runs/7198422780) are failing because `protoc-gen-go` is not installed. This is package is installed as part of `tools/tools.go` which is built by `make install`. Not all Make targets that require `protoc-gen-go` run `make install` first, but this likely worked intermittently due to step caching and parallelism.

##### Does this PR introduce a user-facing change?
```
NONE
```